### PR TITLE
Polish portfolio page structure and fix ArtStation embed

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: light dark;
+  --background-color: #f4f4f4;
+  --text-color: #0a0a0a;
+  --footer-background: rgba(0, 0, 0, 0.85);
+  --focus-outline: #1a73e8;
+  --panel-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
+  --noscript-background: #1f1f1f;
+  --noscript-text: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #090909;
+    --text-color: #f5f5f5;
+    --footer-background: rgba(15, 15, 15, 0.88);
+    --focus-outline: #8ab4f8;
+    --panel-shadow: 0 6px 12px rgba(0, 0, 0, 0.6);
+    --noscript-background: #121212;
+    --noscript-text: #f5f5f5;
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.5;
+}
+
+main {
+  flex: 1 0 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.portfolio-frame {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 600px;
+  aspect-ratio: 16 / 9;
+  border: none;
+  background-color: #000;
+}
+
+.portfolio-fallback {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 1rem;
+  background-color: rgba(0, 0, 0, 0.05);
+  color: inherit;
+}
+
+@media (prefers-color-scheme: dark) {
+  .portfolio-fallback {
+    background-color: rgba(255, 255, 255, 0.06);
+  }
+}
+
+.portfolio-fallback a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.social-bar {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background: var(--footer-background);
+  padding: 10px 16px;
+  display: flex;
+  justify-content: center;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.social-links {
+  display: flex;
+  gap: 35px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.social-links li {
+  margin: 0;
+}
+
+.social-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.social-links img {
+  width: 100%;
+  height: 100%;
+}
+
+.social-links a:hover,
+.social-links a:focus-visible {
+  transform: scale(1.1);
+  box-shadow: var(--panel-shadow);
+}
+
+.social-links a:focus-visible {
+  outline: 3px solid var(--focus-outline);
+  outline-offset: 4px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.noscript-warning {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 1rem;
+  background-color: var(--noscript-background);
+  color: var(--noscript-text);
+}
+
+@media (max-width: 1024px) {
+  .social-links {
+    gap: 28px;
+  }
+
+  .social-links a {
+    width: 35px;
+    height: 35px;
+  }
+}
+
+@media (max-width: 767px) {
+  .social-bar {
+    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+  }
+
+  .social-links {
+    gap: 24px;
+  }
+
+  .social-links a {
+    width: 30px;
+    height: 30px;
+  }
+}
+
+@media (max-height: 700px) {
+  .portfolio-frame {
+    min-height: 480px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .social-links a {
+    transition: none;
+  }
+
+  .social-links a:hover,
+  .social-links a:focus-visible {
+    transform: none;
+    box-shadow: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,1 +1,167 @@
-<!DOCTYPE html><html lang="ru"><head><script async src="https://www.googletagmanager.com/gtag/js?id=G-TNJMJ6JWD6"></script><script>function gtag(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],gtag("js",new Date),gtag("config","G-TNJMJ6JWD6")</script><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><link id="favicon-dark" rel="icon" href="assets/FaviconDark.ico" type="image/x-icon" media="(prefers-color-scheme: light)"><link id="favicon-Light" rel="icon" href="assets/FaviconLight.ico" type="image/x-icon" media="(prefers-color-scheme: dark)"><title>Dmitrii Popov</title><meta name="description" content="Portfolio"><meta name="twitter:site_name" content="Dmitrii Popov"><meta name="twitter:title" content="Dmitrii Popov"><meta name="twitter:card" content="summary"><meta name="twitter:description" content="Portfolio"><meta name="twitter:image" content="https://popov-da.ru/preview.jpg"><meta property="og:url" content="https://popov-da.ru/"><meta property="og:site_name" content="Dmitrii Popov"><meta property="og:title" content="Dmitrii Popov"><meta property="og:image" content="https://popov-da.ru/preview.jpg"><meta property="og:description" content="Portfolio"><meta property="og:type" content="website"><meta name="image" content="https://popov-da.ru/preview.jpg"><style>body{font-family:Arial,sans-serif;margin:0;padding:0;background-color:#f4f4f4}.container{position:relative;height:100vh;display:flex;flex-direction:column}.content{flex:1}iframe{width:100%;height:calc(100vh - 60px);border:none;min-height:600px;aspect-ratio:16/9}.bottom-bar{position:sticky;bottom:0;width:100%;background:rgba(0,0,0,.8);display:flex;justify-content:center;padding:10px 0;gap:35px;min-height:30px}.bottom-bar img{width:40px;height:40px;transition:transform .2s}.bottom-bar img:hover{transform:scale(1.1)}@media (max-width:767px){.bottom-bar{box-shadow:0 -2px 5px rgba(0,0,0,.2);justify-content:space-around;border-top:1px solid #ccc}.bottom-bar a{color:#333}.bottom-bar img{width:30px;height:30px}}@media (max-width:1025px){.bottom-bar img{width:35px;height:35px}}</style></head><body><div class="container"><div class="content"><iframe src="https://dpopov.artstation.com/" title="ArtStation Portfolio"></iframe></div><div class="bottom-bar"><a href="https://github.com/popov-da" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/2/24/Github_logo_svg.svg" alt="GitHub"></a><a href="https://t.me/dmtr_popov" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/8/82/Telegram.svg" alt="Telegram"></a><a href="mailto:dmi.popov@bk.ru"><img src="https://upload.wikimedia.org/wikipedia/commons/8/82/Aiga_mail_white.svg" alt="Email"></a><a href="https://www.linkedin.com/in/dmitrii-popov-860721243" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b0/Linkedin_footer.svg" alt="LinkedIn"></a><a href="https://hh.ru/resume/ea64e41eff0786e5ee0039ed1f30776c317374" target="_blank"><img src="assets/HH.ru.svg" alt="HeadHunter"></a></div></div></body></html>
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dmitrii Popov</title>
+    <meta name="description" content="Portfolio" />
+    <meta name="author" content="Dmitrii Popov" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#f4f4f4" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#090909" media="(prefers-color-scheme: dark)" />
+    <meta property="og:url" content="https://popov-da.ru/" />
+    <meta property="og:site_name" content="Dmitrii Popov" />
+    <meta property="og:title" content="Dmitrii Popov" />
+    <meta property="og:description" content="Portfolio" />
+    <meta property="og:image" content="https://popov-da.ru/preview.jpg" />
+    <meta property="og:image:alt" content="Работы Дмитрия Попова" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ru_RU" />
+    <meta name="image" content="https://popov-da.ru/preview.jpg" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Dmitrii Popov" />
+    <meta name="twitter:description" content="Portfolio" />
+    <meta name="twitter:image" content="https://popov-da.ru/preview.jpg" />
+    <meta name="twitter:image:alt" content="Работы Дмитрия Попова" />
+    <link rel="canonical" href="https://popov-da.ru/" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+    <link rel="preconnect" href="https://www.google-analytics.com" crossorigin />
+    <link
+      id="favicon-dark"
+      rel="icon"
+      href="assets/FaviconDark.ico"
+      type="image/x-icon"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      id="favicon-Light"
+      rel="icon"
+      href="assets/FaviconLight.ico"
+      type="image/x-icon"
+      media="(prefers-color-scheme: dark)"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TNJMJ6JWD6"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-TNJMJ6JWD6");
+    </script>
+  </head>
+  <body>
+    <main id="portfolio" aria-label="Портфолио Дмитрия Попова">
+      <iframe
+        class="portfolio-frame"
+        src="https://www.artstation.com/users/dpopov/embed?album_id=all"
+        title="Портфолио Дмитрия Попова на ArtStation"
+        loading="lazy"
+        allow="autoplay"
+        allowfullscreen
+        scrolling="no"
+        frameborder="0"
+      ></iframe>
+      <p
+        id="portfolio-fallback"
+        class="portfolio-fallback"
+        hidden
+        role="status"
+        aria-live="polite"
+      >
+        Не удалось загрузить интерактивное портфолио. Попробуйте
+        <a href="https://www.artstation.com/dpopov" target="_blank" rel="noopener noreferrer">открыть ArtStation в новой вкладке</a>.
+      </p>
+    </main>
+    <script async src="https://www.artstation.com/widget.js"></script>
+    <script>
+      (function () {
+        const frame = document.querySelector(".portfolio-frame");
+        const fallback = document.getElementById("portfolio-fallback");
+        if (!frame || !fallback) {
+          return;
+        }
+
+        let loaded = false;
+        const showFallback = () => {
+          if (!loaded) {
+            fallback.hidden = false;
+          }
+        };
+
+        const fallbackTimer = window.setTimeout(showFallback, 6000);
+
+        frame.addEventListener("load", () => {
+          loaded = true;
+          fallback.hidden = true;
+          window.clearTimeout(fallbackTimer);
+        });
+
+        frame.addEventListener("error", showFallback);
+      })();
+    </script>
+    <footer class="social-bar">
+      <nav aria-label="Социальные профили и контакты Дмитрия Попова">
+        <ul class="social-links">
+          <li>
+            <a href="https://github.com/popov-da" target="_blank" rel="noopener noreferrer">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/2/24/Github_logo_svg.svg"
+                alt=""
+                aria-hidden="true"
+              />
+              <span class="visually-hidden">GitHub</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://t.me/dmtr_popov" target="_blank" rel="noopener noreferrer">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/8/82/Telegram.svg"
+                alt=""
+                aria-hidden="true"
+              />
+              <span class="visually-hidden">Telegram</span>
+            </a>
+          </li>
+          <li>
+            <a href="mailto:dmi.popov@bk.ru">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/8/82/Aiga_mail_white.svg"
+                alt=""
+                aria-hidden="true"
+              />
+              <span class="visually-hidden">Email</span>
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.linkedin.com/in/dmitrii-popov-860721243"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/b/b0/Linkedin_footer.svg"
+                alt=""
+                aria-hidden="true"
+              />
+              <span class="visually-hidden">LinkedIn</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://hh.ru/resume/ea64e41eff0786e5ee0039ed1f30776c317374" target="_blank" rel="noopener noreferrer">
+              <img src="assets/HH.ru.svg" alt="" aria-hidden="true" />
+              <span class="visually-hidden">HeadHunter</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </footer>
+    <noscript>
+      <p class="noscript-warning">
+        Для корректной работы аналитики на сайте необходимо включить JavaScript. Портфолио ArtStation
+        продолжит отображаться и без него.
+      </p>
+    </noscript>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- reformat the landing page markup, expand social metadata, and add accessibility improvements for the ArtStation embed
- move styling into a dedicated stylesheet with responsive layout tweaks, custom properties, and focus states for keyboard users
- add a noscript message and link hardening (rel noopener) while preserving the existing favicon setup
- switch the ArtStation iframe to the official widget embed, drop conflicting attributes, and surface a graceful fallback link when loading fails

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c9628ec474832b8065b01c5f9a2be1